### PR TITLE
refactor: remove deprecated OAuth token query parameter flow

### DIFF
--- a/internal/interfaces/http/auth.go
+++ b/internal/interfaces/http/auth.go
@@ -8,7 +8,6 @@ import (
 	"html/template"
 	"log"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -85,15 +84,13 @@ func (h *AuthHandler) HandleAuthURL(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleMobileAuthStart generates OAuth URL for mobile app.
-// Embeds the client version from User-Agent into the OAuth state so the callback
-// can determine which flow to use (the callback User-Agent is the browser, not the app).
 func (h *AuthHandler) HandleMobileAuthStart(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	state, err := generateStateWithVersion(r.UserAgent())
+	state, err := generateState()
 	if err != nil {
 		log.Printf("Error generating OAuth state: %v", err)
 		http.Error(w, "Failed to generate state", http.StatusInternalServerError)
@@ -112,108 +109,6 @@ func generateState() (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(b), nil
-}
-
-// generateStateWithVersion creates an OAuth state that embeds the client version.
-// Format: base64url(random_bytes).version_string
-// This allows the callback to determine the client version even when the callback
-// comes from the OAuth provider's server (e.g. Apple form_post).
-func generateStateWithVersion(ua string) (string, error) {
-	state, err := generateState()
-	if err != nil {
-		return "", err
-	}
-	version := extractParsaVersion(ua)
-	if version != "" {
-		state = state + "." + version
-	}
-	return state, nil
-}
-
-// parseStateVersion extracts the version suffix from a state parameter.
-// State format: "base64urlRandomBytes.major.minor.patch"
-// Base64url characters are [A-Za-z0-9_-=], so the first '.' always marks the version boundary.
-func parseStateVersion(state string) (string, string) {
-	idx := strings.Index(state, ".")
-	if idx < 0 {
-		return state, ""
-	}
-	candidate := state[idx+1:]
-	_, _, _, ok := parseVersionString(candidate)
-	if ok {
-		return state[:idx], candidate
-	}
-	return state, ""
-}
-
-// extractParsaVersion extracts the version string from a Parsa User-Agent.
-// UA format: ({os}) Parsa/{major}.{minor}.{patch}+{build}
-// Returns "2.16.0" or empty string if not a Parsa client.
-func extractParsaVersion(ua string) string {
-	idx := strings.Index(ua, "Parsa/")
-	if idx < 0 {
-		return ""
-	}
-	versionPart := ua[idx+len("Parsa/"):]
-	if plusIdx := strings.Index(versionPart, "+"); plusIdx >= 0 {
-		versionPart = versionPart[:plusIdx]
-	}
-	if spaceIdx := strings.Index(versionPart, " "); spaceIdx >= 0 {
-		versionPart = versionPart[:spaceIdx]
-	}
-	return versionPart
-}
-
-// parseParsaVersion parses a Parsa User-Agent and returns the semantic version.
-func parseParsaVersion(ua string) (major, minor, patch int, ok bool) {
-	version := extractParsaVersion(ua)
-	if version == "" {
-		return 0, 0, 0, false
-	}
-	return parseVersionString(version)
-}
-
-func parseVersionString(version string) (major, minor, patch int, ok bool) {
-	parts := strings.Split(version, ".")
-	if len(parts) != 3 {
-		return 0, 0, 0, false
-	}
-	var err error
-	major, err = strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, 0, 0, false
-	}
-	minor, err = strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, 0, 0, false
-	}
-	patch, err = strconv.Atoi(parts[2])
-	if err != nil {
-		return 0, 0, 0, false
-	}
-	return major, minor, patch, true
-}
-
-// shouldUseAuthCodeFlow returns true if the client supports the auth code exchange flow.
-// Clients >= 2.16.0 use the new flow. Unknown/non-Parsa clients default to the new secure flow.
-func shouldUseAuthCodeFlow(ua string) bool {
-	major, minor, _, ok := parseParsaVersion(ua)
-	if !ok {
-		return true
-	}
-	return major > 2 || (major == 2 && minor >= 16)
-}
-
-// shouldUseAuthCodeFlowFromVersion checks a version string (e.g. "2.16.0") directly.
-func shouldUseAuthCodeFlowFromVersion(version string) bool {
-	if version == "" {
-		return true
-	}
-	major, minor, _, ok := parseVersionString(version)
-	if !ok {
-		return true
-	}
-	return major > 2 || (major == 2 && minor >= 16)
 }
 
 // mobileRedirectURL builds the deep-link redirect URL for mobile OAuth callbacks.
@@ -300,7 +195,6 @@ func (h *AuthHandler) HandleMobileAuthCallback(w http.ResponseWriter, r *http.Re
 	}
 
 	code := r.URL.Query().Get("code")
-	state := r.URL.Query().Get("state")
 	oauthError := r.URL.Query().Get("error")
 
 	if oauthError != "" {
@@ -372,26 +266,18 @@ func (h *AuthHandler) HandleMobileAuthCallback(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Extract client version from state (embedded during /start by the actual app)
-	_, clientVersion := parseStateVersion(state)
-	if shouldUseAuthCodeFlowFromVersion(clientVersion) {
-		authCode, err := h.authCodeStore.Generate(jwtToken, userModel.ID)
-		if err != nil {
-			log.Printf("Mobile OAuth: Failed to generate auth code: %v", err)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(map[string]string{"error": "auth_code_failed"})
-			return
-		}
-		http.Redirect(w, r, h.mobileRedirectURL("code", authCode), http.StatusFound)
-	} else {
-		http.Redirect(w, r, h.mobileRedirectURL("token", jwtToken), http.StatusFound)
+	authCode, err := h.authCodeStore.Generate(jwtToken, userModel.ID)
+	if err != nil {
+		log.Printf("Mobile OAuth: Failed to generate auth code: %v", err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "auth_code_failed"})
+		return
 	}
+	http.Redirect(w, r, h.mobileRedirectURL("code", authCode), http.StatusFound)
 }
 
 // HandleAppleMobileAuthStart generates Apple OAuth URL for mobile app.
-// Embeds the client version from User-Agent into the OAuth state so the callback
-// can determine which flow to use (Apple callbacks come from Apple's servers, not the app).
 func (h *AuthHandler) HandleAppleMobileAuthStart(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -403,7 +289,7 @@ func (h *AuthHandler) HandleAppleMobileAuthStart(w http.ResponseWriter, r *http.
 		return
 	}
 
-	state, err := generateStateWithVersion(r.UserAgent())
+	state, err := generateState()
 	if err != nil {
 		log.Printf("Error generating OAuth state: %v", err)
 		http.Error(w, "Failed to generate state", http.StatusInternalServerError)
@@ -439,23 +325,18 @@ func (h *AuthHandler) HandleAppleMobileAuthCallback(w http.ResponseWriter, r *ht
 	}
 
 	code := r.FormValue("code")
-	state := r.FormValue("state")
 	oauthError := r.FormValue("error")
 	userJSON := r.FormValue("user") // Only sent on first authorization
 
-	// Extract client version embedded in the state during /start
-	_, clientVersion := parseStateVersion(state)
-	useAuthCode := shouldUseAuthCodeFlowFromVersion(clientVersion)
-
 	if oauthError != "" {
 		log.Printf("Apple OAuth error: %s", oauthError)
-		h.renderAppleCallbackPage(w, r, "", "", oauthError)
+		h.renderAppleCallbackPage(w, r, "",oauthError)
 		return
 	}
 
 	if code == "" {
 		log.Printf("Apple OAuth: No code received")
-		h.renderAppleCallbackPage(w, r, "", "", "code_required")
+		h.renderAppleCallbackPage(w, r, "","code_required")
 		return
 	}
 
@@ -465,7 +346,7 @@ func (h *AuthHandler) HandleAppleMobileAuthCallback(w http.ResponseWriter, r *ht
 	token, err := h.appleOAuthProvider.ExchangeCode(ctx, code, h.appleMobileCallbackURL)
 	if err != nil {
 		log.Printf("Apple OAuth: Failed to exchange code: %v", err)
-		h.renderAppleCallbackPage(w, r, "", "", "token_exchange_failed")
+		h.renderAppleCallbackPage(w, r, "","token_exchange_failed")
 		return
 	}
 
@@ -473,7 +354,7 @@ func (h *AuthHandler) HandleAppleMobileAuthCallback(w http.ResponseWriter, r *ht
 	userInfo, err := h.appleOAuthProvider.GetUserInfo(ctx, token.AccessToken)
 	if err != nil {
 		log.Printf("Apple OAuth: Failed to get user info: %v", err)
-		h.renderAppleCallbackPage(w, r, "", "", "user_info_failed")
+		h.renderAppleCallbackPage(w, r, "","user_info_failed")
 		return
 	}
 
@@ -505,7 +386,7 @@ func (h *AuthHandler) HandleAppleMobileAuthCallback(w http.ResponseWriter, r *ht
 		})
 		if err != nil {
 			log.Printf("Apple OAuth: Failed to create user: %v", err)
-			h.renderAppleCallbackPage(w, r, "", "", "user_creation_failed")
+			h.renderAppleCallbackPage(w, r, "","user_creation_failed")
 			return
 		}
 	}
@@ -514,21 +395,17 @@ func (h *AuthHandler) HandleAppleMobileAuthCallback(w http.ResponseWriter, r *ht
 	jwtToken, err := h.jwt.Generate(userModel.ID, userModel.Email)
 	if err != nil {
 		log.Printf("Apple OAuth: Error generating JWT for user %d: %v", userModel.ID, err)
-		h.renderAppleCallbackPage(w, r, "", "", "jwt_generation_failed")
+		h.renderAppleCallbackPage(w, r, "","jwt_generation_failed")
 		return
 	}
 
-	if useAuthCode {
-		authCode, err := h.authCodeStore.Generate(jwtToken, userModel.ID)
-		if err != nil {
-			log.Printf("Apple OAuth: Failed to generate auth code: %v", err)
-			h.renderAppleCallbackPage(w, r, "", "", "auth_code_failed")
-			return
-		}
-		h.renderAppleCallbackPage(w, r, "", authCode, "")
-	} else {
-		h.renderAppleCallbackPage(w, r, jwtToken, "", "")
+	authCode, err := h.authCodeStore.Generate(jwtToken, userModel.ID)
+	if err != nil {
+		log.Printf("Apple OAuth: Failed to generate auth code: %v", err)
+		h.renderAppleCallbackPage(w, r, "", "auth_code_failed")
+		return
 	}
+	h.renderAppleCallbackPage(w, r, authCode, "")
 }
 
 type RegisterRequest struct {
@@ -685,8 +562,7 @@ func (h *AuthHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 // renderAppleCallbackPage renders the HTML redirect page for Apple OAuth callback.
-// Pass token for legacy flow, authCode for the new secure flow.
-func (h *AuthHandler) renderAppleCallbackPage(w http.ResponseWriter, r *http.Request, token, authCode, errorMsg string) {
+func (h *AuthHandler) renderAppleCallbackPage(w http.ResponseWriter, r *http.Request, authCode, errorMsg string) {
 	var templateErr error
 	h.templateOnce.Do(func() {
 		h.appleCallbackTemplate, templateErr = template.ParseFS(web.FS, "apple-oauth-callback.html")
@@ -701,8 +577,6 @@ func (h *AuthHandler) renderAppleCallbackPage(w http.ResponseWriter, r *http.Req
 			http.Redirect(w, r, h.mobileRedirectURL("error", errorMsg), http.StatusFound)
 		} else if authCode != "" {
 			http.Redirect(w, r, h.mobileRedirectURL("code", authCode), http.StatusFound)
-		} else if token != "" {
-			http.Redirect(w, r, h.mobileRedirectURL("token", token), http.StatusFound)
 		} else {
 			http.Error(w, "OAuth callback failed", http.StatusInternalServerError)
 		}
@@ -710,7 +584,6 @@ func (h *AuthHandler) renderAppleCallbackPage(w http.ResponseWriter, r *http.Req
 	}
 
 	type templateData struct {
-		TokenJSON  template.JS
 		CodeJSON   template.JS
 		ErrorJSON  template.JS
 		SchemeJSON template.JS
@@ -727,7 +600,6 @@ func (h *AuthHandler) renderAppleCallbackPage(w http.ResponseWriter, r *http.Req
 	}
 
 	data := templateData{
-		TokenJSON:  toJS(token),
 		CodeJSON:   toJS(authCode),
 		ErrorJSON:  toJS(errorMsg),
 		SchemeJSON: toJS(h.mobileAppScheme),
@@ -740,8 +612,6 @@ func (h *AuthHandler) renderAppleCallbackPage(w http.ResponseWriter, r *http.Req
 			http.Redirect(w, r, h.mobileRedirectURL("error", errorMsg), http.StatusFound)
 		} else if authCode != "" {
 			http.Redirect(w, r, h.mobileRedirectURL("code", authCode), http.StatusFound)
-		} else if token != "" {
-			http.Redirect(w, r, h.mobileRedirectURL("token", token), http.StatusFound)
 		}
 	}
 }

--- a/internal/web/apple-oauth-callback.html
+++ b/internal/web/apple-oauth-callback.html
@@ -45,7 +45,6 @@
     </div>
 
     <script>
-        var token = {{.TokenJSON}};
         var authCode = {{.CodeJSON}};
         var error = {{.ErrorJSON}};
         var scheme = {{.SchemeJSON}};
@@ -67,14 +66,6 @@
             setTimeout(function() {
                 document.getElementById('submessage').innerHTML =
                     'If you are not redirected, <a href="' + codeRedirect + '" style="color: #4dabf7;">click here</a>';
-            }, 2000);
-        } else if (token) {
-            var successRedirect = deepLinkBase + '?token=' + encodeURIComponent(token);
-            window.location.href = successRedirect;
-            setTimeout(function() { window.location.href = successRedirect; }, 500);
-            setTimeout(function() {
-                document.getElementById('submessage').innerHTML =
-                    'If you are not redirected, <a href="' + successRedirect + '" style="color: #4dabf7;">click here</a>';
             }, 2000);
         } else {
             document.getElementById('message').textContent = 'Invalid Response';


### PR DESCRIPTION
## Summary

- Removes the legacy OAuth flow that passed JWT tokens as query parameters for mobile clients < v2.16.0 (PR #53 / Issue #12 transition window)
- All mobile OAuth callbacks (Google and Apple) now exclusively use the secure auth code exchange flow
- Removes ~140 lines of version parsing/comparison logic that is no longer needed
